### PR TITLE
adds missing Empty token marker to documentation

### DIFF
--- a/yaml2yeast/Main.hs
+++ b/yaml2yeast/Main.hs
@@ -128,6 +128,8 @@
 --
 --  [@-@] Unparsed text following error point.
 --
+--  [@~@] Empty Token
+--
 -- In addition, the following code is used for testing partial productions
 -- and do not appear when parsing a complete YAML stream:
 --


### PR DESCRIPTION
I believe that since I have encountered the Empty token in my own testing (I think?) that it should be included here.

thanks!